### PR TITLE
Fixed incorrect mapping of build dist in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "4.0.0",
   "description": "Typescript client for Manticore Search",
   "license": "MIT",
-  "main": "./dist/index.js",
-  "typings": "./dist/index.d.ts",
+  "main": "./dist/src/index.js",
+  "typings": "./dist/src/index.d.ts",
   "scripts": {
     "build": "tsc",
     "test": "cross-env TS_NODE_COMPILER_OPTIONS='{\"module\": \"commonjs\" }' mocha -r ts-node/register 'test/**/*.test.ts'",
@@ -23,7 +23,7 @@
     "search",
     "client",
     "index"
-  ],  
+  ],
   "peerDependencies": {
     "typescript": ">=4.0"
   },
@@ -31,7 +31,7 @@
     "typescript": {
       "optional": true
     }
-  },  
+  },
   "devDependencies": {
     "@types/chai": "^4.3.9",
     "@types/mocha": "^10.0.3",


### PR DESCRIPTION
Fix entrypoint being mapped incorrectly after build in `package.json`

Link to issue #5 

before 
![image](https://github.com/manticoresoftware/manticoresearch-typescript/assets/95325223/5b85a2b5-429a-4ef6-afca-6c7904d4420c)

after
![image](https://github.com/manticoresoftware/manticoresearch-typescript/assets/95325223/99b5db0d-6bb2-468c-99de-ce5314942e3c)

